### PR TITLE
Add azure-monitor dependencies to project configuration

### DIFF
--- a/app/copilot/pyproject.toml
+++ b/app/copilot/pyproject.toml
@@ -13,7 +13,9 @@ dependencies = [
     "azure-storage-blob==12.26.0",
     "azure-ai-documentintelligence==1.0.1",
     "dependency-injector==4.48.1",
-    "agent-framework-azure-ai"
+    "agent-framework-azure-ai",
+    "azure-monitor-opentelemetry-exporter>=1.0.0b42",
+    "azure-monitor-opentelemetry>=1.8.1",
 ]
 
 

--- a/app/copilot/uv.lock
+++ b/app/copilot/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "agent-framework-azure-ai"
 version = "1.0.0b251001"
@@ -339,6 +336,8 @@ dependencies = [
     { name = "agent-framework-azure-ai" },
     { name = "azure-ai-documentintelligence" },
     { name = "azure-identity" },
+    { name = "azure-monitor-opentelemetry" },
+    { name = "azure-monitor-opentelemetry-exporter" },
     { name = "azure-storage-blob" },
     { name = "dependency-injector" },
     { name = "fastapi", extra = ["all"] },
@@ -357,6 +356,8 @@ requires-dist = [
     { name = "agent-framework-azure-ai" },
     { name = "azure-ai-documentintelligence", specifier = "==1.0.1" },
     { name = "azure-identity", specifier = "==1.24.0" },
+    { name = "azure-monitor-opentelemetry", specifier = ">=1.8.1" },
+    { name = "azure-monitor-opentelemetry-exporter", specifier = ">=1.0.0b42" },
     { name = "azure-storage-blob", specifier = "==12.26.0" },
     { name = "dependency-injector", specifier = "==4.48.1" },
     { name = "fastapi", extras = ["all"], specifier = "==0.116.1" },


### PR DESCRIPTION
This pull request updates the dependencies in `app/copilot/pyproject.toml` to enable integration with Azure Monitor and OpenTelemetry. These additions will allow the application to export telemetry data and improve monitoring capabilities.

Monitoring and telemetry integration:

* Added `azure-monitor-opentelemetry-exporter` and `azure-monitor-opentelemetry` packages to the dependencies list to support Azure Monitor and OpenTelemetry features.